### PR TITLE
fix: namespace for extension-apiserver-authentication rolebinding

### DIFF
--- a/charts/proxmox-cloud-controller-manager/Chart.yaml
+++ b/charts/proxmox-cloud-controller-manager/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/proxmox-cloud-controller-manager/README.md
+++ b/charts/proxmox-cloud-controller-manager/README.md
@@ -1,6 +1,6 @@
 # proxmox-cloud-controller-manager
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/proxmox-cloud-controller-manager/templates/rolebinding.yaml
+++ b/charts/proxmox-cloud-controller-manager/templates/rolebinding.yaml
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: system:{{ include "proxmox-cloud-controller-manager.fullname" . }}:extension-apiserver-authentication-reader
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/docs/deploy/cloud-controller-manager-talos.yml
+++ b/docs/deploy/cloud-controller-manager-talos.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.1.6
+    helm.sh/chart: proxmox-cloud-controller-manager-0.1.7
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"


### PR DESCRIPTION
# Pull Request

## What? (description)

Helm chart includes rolebinding which installed in release namespace for role persists in `kube-system` namespace.

This will not work if chart deployed in separate namesapce

## Why? (reasoning)

role `extension-apiserver-authentication-reader` originally persists in`kube-system` namespace, the rolebinding must be created in same namespace

related log:

```
I1010 11:00:48.283722       1 serving.go:348] Generated self-signed cert in-memory
I1010 11:00:48.368155       1 serving.go:348] Generated self-signed cert in-memory
W1010 11:00:48.368198       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W1010 11:00:48.680596       1 requestheader_controller.go:193] Unable to get configmap/extension-apiserver-authentication in kube-system.  Usually fixed by 'kubectl create rolebinding -n kube-system ROLEBINDING_NAME --role=extension-apiserver-authentication-reader --serviceaccount=YOUR_NS:YOUR_SA'
unable to load configmap based request-header-client-ca-file: configmaps "extension-apiserver-authentication" is forbidden: User "system:serviceaccount:infra-proxmox:proxmox-proxmox-cloud-controller-manager" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
E1010 11:00:48.680643       1 run.go:74] "command failed" err="unable to load configmap based request-header-client-ca-file: configmaps \"extension-apiserver-authentication\" is forbidden: User \"system:serviceaccount:infra-proxmox:proxmox-proxmox-cloud-controller-manager\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"kube-system\""
```


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

