### PR TITLE
replace nodeSelector with nodeAffinity in chart + manifests

### DIFF
--- a/charts/proxmox-cloud-controller-manager/Chart.yaml
+++ b/charts/proxmox-cloud-controller-manager/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/proxmox-cloud-controller-manager/README.md
+++ b/charts/proxmox-cloud-controller-manager/README.md
@@ -35,8 +35,13 @@ enabledControllers:
   - cloud-node-lifecycle
 
 # Deploy CCM only on control-plane nodes
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     effect: NoSchedule

--- a/charts/proxmox-cloud-controller-manager/README.md.gotmpl
+++ b/charts/proxmox-cloud-controller-manager/README.md.gotmpl
@@ -33,8 +33,13 @@ enabledControllers:
   - cloud-node-lifecycle
 
 # Deploy CCM only on control-plane nodes
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     effect: NoSchedule

--- a/charts/proxmox-cloud-controller-manager/ci/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/ci/values.yaml
@@ -1,11 +1,15 @@
-
 image:
   repository: ghcr.io/sergelogvinov/proxmox-cloud-controller-manager
   pullPolicy: Always
   tag: edge
 
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
 logVerbosityLevel: 4
 

--- a/charts/proxmox-cloud-controller-manager/values.edge.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.edge.yaml
@@ -1,10 +1,14 @@
-
 image:
   pullPolicy: Always
   tag: edge
 
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
 logVerbosityLevel: 4
 

--- a/charts/proxmox-cloud-controller-manager/values.talos.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.talos.yaml
@@ -1,6 +1,10 @@
-
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
 
 logVerbosityLevel: 4
 

--- a/charts/proxmox-cloud-controller-manager/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.yaml
@@ -123,6 +123,12 @@ tolerations:
 # -- Affinity for data pods assignment.
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#      - matchExpressions:
+#        - key: node-role.kubernetes.io/control-plane
+#          operator: Exists
 
 # -- Additional volumes for Pods
 extraVolumes: []

--- a/docs/deploy/cloud-controller-manager-talos.yml
+++ b/docs/deploy/cloud-controller-manager-talos.yml
@@ -172,8 +172,13 @@ spec:
             - name: cloud-config
               mountPath: /etc/proxmox
               readOnly: true
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -172,8 +172,13 @@ spec:
             - name: cloud-config
               mountPath: /etc/proxmox
               readOnly: true
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? Why? 
While playing around with https://github.com/ionos-cloud/cluster-api-provider-proxmox and https://github.com/cluster-api-provider-k3s/cluster-api-k3s i noticed, that K3s sets the control-plane label as
```yaml
node-role.kubernetes.io/control-plane: "true"
```
whereas the chart and standard deploy manifests of proxmox-cloud-controller-manager expect
```yaml
node-role.kubernetes.io/control-plane: ""
```
in the `nodeSelector`. Causing the nodes to never become initialized. 

Therefore, switching out the existing
```yaml
nodeSelector:
  node-role.kubernetes.io/control-plane: ""
```
with a simple
```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: node-role.kubernetes.io/control-plane
          operator: Exists
```
will not break existing deployments and accept both an empty label, as well a label that's defined as `true`.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
