### PR TITLE
feat: can use user/password

### DIFF
--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -50,7 +50,13 @@ func NewCluster(config *ClustersConfig, hclient *http.Client) (*Cluster, error) 
 				return nil, err
 			}
 
-			client.SetAPIToken(cfg.TokenID, cfg.TokenSecret)
+			if cfg.Username != "" && cfg.Password != "" {
+				if err := client.Login(cfg.Username, cfg.Password, ""); err != nil {
+					return nil, err
+				}
+			} else {
+				client.SetAPIToken(cfg.TokenID, cfg.TokenSecret)
+			}
 
 			proxmox[cfg.Region] = client
 		}

--- a/pkg/cluster/cloud_config.go
+++ b/pkg/cluster/cloud_config.go
@@ -33,6 +33,8 @@ type ClustersConfig struct {
 		Insecure    bool   `yaml:"insecure,omitempty"`
 		TokenID     string `yaml:"token_id,omitempty"`
 		TokenSecret string `yaml:"token_secret,omitempty"`
+		Username    string `yaml:"username,omitempty"`
+		Password    string `yaml:"password,omitempty"`
 		Region      string `yaml:"region,omitempty"`
 	} `yaml:"clusters,omitempty"`
 }
@@ -48,12 +50,12 @@ func ReadCloudConfig(config io.Reader) (ClustersConfig, error) {
 	}
 
 	for idx, c := range cfg.Clusters {
-		if c.TokenID == "" {
-			return ClustersConfig{}, fmt.Errorf("cluster #%d: token_id is required", idx+1)
-		}
-
-		if c.TokenSecret == "" {
-			return ClustersConfig{}, fmt.Errorf("cluster #%d: token_secret is required", idx+1)
+		if c.Username != "" && c.Password != "" {
+			if c.TokenID != "" || c.TokenSecret != "" {
+				return ClustersConfig{}, fmt.Errorf("cluster #%d: token_id and token_secret are not allowed when username and password are set", idx+1)
+			}
+		} else if c.TokenID == "" || c.TokenSecret == "" {
+			return ClustersConfig{}, fmt.Errorf("cluster #%d: either username and password or token_id and token_secret are required", idx+1)
 		}
 
 		if c.Region == "" {

--- a/pkg/cluster/cloud_config_test.go
+++ b/pkg/cluster/cloud_config_test.go
@@ -68,6 +68,19 @@ clusters:
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 1, len(cfg.Clusters))
+
+	// Valid config with one cluster (username/password)
+	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+clusters:
+  - url: https://example.com
+    insecure: false
+    username: "user@pam"
+    password: "secret"
+    region: cluster-1
+`))
+	assert.Nil(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, 1, len(cfg.Clusters))
 }
 
 func TestReadCloudConfigFromFile(t *testing.T) {


### PR DESCRIPTION
Some method in Proxmox required root permissions (account). So we can pass it through cluster config.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
