### PR TITLE
feat: kubelet dualstack support

### DIFF
--- a/pkg/proxmox/instances.go
+++ b/pkg/proxmox/instances.go
@@ -138,7 +138,12 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 			}
 		}
 
-		addresses := []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: providedIP}}
+		addresses := []v1.NodeAddress{}
+
+		for _, ip := range strings.Split(providedIP, ",") {
+			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip})
+		}
+
 		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: node.Name})
 
 		instanceType, err := i.getInstanceType(vmRef, region)

--- a/pkg/proxmox/instances_test.go
+++ b/pkg/proxmox/instances_test.go
@@ -417,6 +417,37 @@ func (ts *ccmTestSuite) TestInstanceMetadata() {
 			},
 		},
 		{
+			msg: "NodeExistsDualstack",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-1-node-1",
+					Annotations: map[string]string{
+						cloudproviderapi.AnnotationAlphaProvidedIPAddr: "1.2.3.4,2001::1",
+					},
+				},
+			},
+			expected: &cloudprovider.InstanceMetadata{
+				ProviderID: "proxmox://cluster-1/100",
+				NodeAddresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeInternalIP,
+						Address: "1.2.3.4",
+					},
+					{
+						Type:    v1.NodeInternalIP,
+						Address: "2001::1",
+					},
+					{
+						Type:    v1.NodeHostName,
+						Address: "cluster-1-node-1",
+					},
+				},
+				InstanceType: "4VCPU-10GB",
+				Region:       "cluster-1",
+				Zone:         "pve-1",
+			},
+		},
+		{
 			msg: "NodeExistsCluster2",
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Enable cloud Dual-Stack with --node-ip support since Kubernetes 1.29 release.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
