### PR TITLE
add hostNetwork to helm chart

### DIFF
--- a/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "proxmox-cloud-controller-manager.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       enableServiceLinks: false
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/proxmox-cloud-controller-manager/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+# -- hostnetwork when the pods network can't reach proxmox 
+# for example with calico , the nodes tainted and calico controller will not run change to true
+hostNetwork: false
+
 image:
   # -- Proxmox CCM image.
   repository: ghcr.io/sergelogvinov/proxmox-cloud-controller-manager


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)
adding ability to run on host network in the helm chart.
## Why? (reasoning)
when deploying cluster with calico, calico controller will stuck in pending state because of `node.cloudprovider.kubernetes.io/uninitialized` taint. 

same with coredns chart 
this prevents the CCM reaching to proxmox and the cluster will stuck in pending state.

so instead of changing 2 charts more native and efficient way is to just run the cloud controller as host network. 


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
