### PR TITLE
feat: Add support for caluster api/capmox

### DIFF
--- a/charts/proxmox-cloud-controller-manager/README.md
+++ b/charts/proxmox-cloud-controller-manager/README.md
@@ -77,33 +77,33 @@ helm upgrade -i --namespace=kube-system -f proxmox-ccm.yaml \
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| replicaCount | int | `1` |  |
-| image.repository | string | `"ghcr.io/sergelogvinov/proxmox-cloud-controller-manager"` | Proxmox CCM image. |
-| image.pullPolicy | string | `"IfNotPresent"` | Always or IfNotPresent |
-| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| imagePullSecrets | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| fullnameOverride | string | `""` |  |
-| extraArgs | list | `[]` | Any extra arguments for talos-cloud-controller-manager |
-| enabledControllers | list | `["cloud-node","cloud-node-lifecycle"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node,cloud-node-lifecycle` controllers. |
+| Key | Type | Default | Description                                                                                                                                                                    |
+|-----|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| replicaCount | int | `1` |                                                                                                                                                                                |
+| image.repository | string | `"ghcr.io/sergelogvinov/proxmox-cloud-controller-manager"` | Proxmox CCM image.                                                                                                                                                             |
+| image.pullPolicy | string | `"IfNotPresent"` | Always or IfNotPresent                                                                                                                                                         |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion.                                                                                                                 |
+| imagePullSecrets | list | `[]` |                                                                                                                                                                                |
+| nameOverride | string | `""` |                                                                                                                                                                                |
+| fullnameOverride | string | `""` |                                                                                                                                                                                |
+| extraArgs | list | `[]` | Any extra arguments for talos-cloud-controller-manager, eg --capi=true to enable cluster api compatibility.                                                                    |
+| enabledControllers | list | `["cloud-node","cloud-node-lifecycle"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node,cloud-node-lifecycle` controllers.                                          |
 | logVerbosityLevel | int | `2` | Log verbosity level. See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md for description of individual verbosity levels. |
-| existingConfigSecret | string | `nil` | Proxmox cluster config stored in secrets. |
-| existingConfigSecretKey | string | `"config.yaml"` | Proxmox cluster config stored in secrets key. |
-| config | object | `{"clusters":[]}` | Proxmox cluster config. |
-| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Pods Service Account. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
-| priorityClassName | string | `"system-cluster-critical"` | CCM pods' priorityClassName. |
-| initContainers | list | `[]` | Add additional init containers to the CCM pods. ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |
-| hostAliases | list | `[]` | hostAliases Deployment pod host aliases ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/ |
-| podAnnotations | object | `{}` | Annotations for data pods. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| podSecurityContext | object | `{"fsGroup":10258,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":10258,"runAsNonRoot":true,"runAsUser":10258}` | Pods Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
-| resources | object | `{"requests":{"cpu":"10m","memory":"32Mi"}}` | Resource requests and limits. ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| useDaemonSet | bool | `false` | Deploy CCM  in Daemonset mode. CCM will use hostNetwork. It allows to use CCM without CNI plugins. |
-| updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Deployment update strategy type. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment |
-| nodeSelector | object | `{}` | Node labels for data pods assignment. ref: https://kubernetes.io/docs/user-guide/node-selection/ |
-| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","operator":"Exists"}]` | Tolerations for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
-| affinity | object | `{}` | Affinity for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
-| extraVolumes | list | `[]` | Additional volumes for Pods |
-| extraVolumeMounts | list | `[]` | Additional volume mounts for Pods |
+| existingConfigSecret | string | `nil` | Proxmox cluster config stored in secrets.                                                                                                                                      |
+| existingConfigSecretKey | string | `"config.yaml"` | Proxmox cluster config stored in secrets key.                                                                                                                                  |
+| config | object | `{"clusters":[]}` | Proxmox cluster config.                                                                                                                                                        |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Pods Service Account. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/                                                                 |
+| priorityClassName | string | `"system-cluster-critical"` | CCM pods' priorityClassName.                                                                                                                                                   |
+| initContainers | list | `[]` | Add additional init containers to the CCM pods. ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/                                                       |
+| hostAliases | list | `[]` | hostAliases Deployment pod host aliases ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/                                                           |
+| podAnnotations | object | `{}` | Annotations for data pods. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/                                                                 |
+| podSecurityContext | object | `{"fsGroup":10258,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":10258,"runAsNonRoot":true,"runAsUser":10258}` | Pods Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod                                      |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod                                 |
+| resources | object | `{"requests":{"cpu":"10m","memory":"32Mi"}}` | Resource requests and limits. ref: https://kubernetes.io/docs/user-guide/compute-resources/                                                                                    |
+| useDaemonSet | bool | `false` | Deploy CCM  in Daemonset mode. CCM will use hostNetwork. It allows to use CCM without CNI plugins.                                                                             |
+| updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Deployment update strategy type. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment                                              |
+| nodeSelector | object | `{}` | Node labels for data pods assignment. ref: https://kubernetes.io/docs/user-guide/node-selection/                                                                               |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","operator":"Exists"}]` | Tolerations for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                             |
+| affinity | object | `{}` | Affinity for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity                                          |
+| extraVolumes | list | `[]` | Additional volumes for Pods                                                                                                                                                    |
+| extraVolumeMounts | list | `[]` | Additional volume mounts for Pods                                                                                                                                              |

--- a/charts/proxmox-cloud-controller-manager/values.capi.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.capi.yaml
@@ -1,0 +1,2 @@
+extraArgs:
+  - --capi-enabled=true

--- a/cmd/proxmox-cloud-controller-manager/main.go
+++ b/cmd/proxmox-cloud-controller-manager/main.go
@@ -51,6 +51,9 @@ func main() {
 	fss := cliflag.NamedFlagSets{}
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, app.DefaultInitFuncConstructors, names.CCMControllerAliases(), fss, wait.NeverStop)
 
+	capiEnabled := false
+	command.Flags().BoolVar(&capiEnabled, "capi-enabled", false, "Enable CAPI mode for Proxmox cloud provider")
+
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Name == "cloud-provider" {
 			if err := flag.Value.Set(proxmox.ProviderName); err != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -38,6 +38,11 @@ func GetProviderID(region string, vmr *pxapi.VmRef) string {
 	return fmt.Sprintf("%s://%s/%d", ProviderName, region, vmr.VmId())
 }
 
+// GetProviderIDFromUUID returns the magic providerID for kubernetes node.
+func GetProviderIDFromUUID(uuid string) string {
+	return fmt.Sprintf("%s://%s", ProviderName, uuid)
+}
+
 // GetVMID returns the VM ID from the providerID.
 func GetVMID(providerID string) (int, error) {
 	if !strings.HasPrefix(providerID, ProviderName) {

--- a/pkg/proxmox/cloud.go
+++ b/pkg/proxmox/cloud.go
@@ -65,7 +65,8 @@ func newCloud(config *cluster.ClustersConfig) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 
-	instancesInterface := newInstances(client)
+	// TODO: how to inject capiEnabled flag from main.go?
+	instancesInterface := newInstances(client, false)
 
 	return &cloud{
 		client:      client,

--- a/pkg/proxmox/instances.go
+++ b/pkg/proxmox/instances.go
@@ -34,12 +34,14 @@ import (
 )
 
 type instances struct {
-	c *cluster.Cluster
+	c    *cluster.Cluster
+	capi bool
 }
 
-func newInstances(client *cluster.Cluster) *instances {
+func newInstances(client *cluster.Cluster, capi bool) *instances {
 	return &instances{
-		c: client,
+		c:    client,
+		capi: capi,
 	}
 }
 
@@ -149,6 +151,12 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 					return nil, fmt.Errorf("instances.InstanceMetadata() - failed to find instance by name/uuid %s: %v, skipped", node.Name, err)
 				}
 			}
+
+			if i.capi {
+				providerID = provider.GetProviderIDFromUUID(uuid)
+			} else {
+				providerID = provider.GetProviderID(region, vmRef)
+			}
 		} else if !strings.HasPrefix(node.Spec.ProviderID, provider.ProviderName) {
 			klog.V(4).InfoS("instances.InstanceMetadata() omitting unmanaged node", "node", klog.KObj(node), "providerID", node.Spec.ProviderID)
 
@@ -178,7 +186,7 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 		}
 
 		return &cloudprovider.InstanceMetadata{
-			ProviderID:    provider.GetProviderID(region, vmRef),
+			ProviderID:    providerID,
 			NodeAddresses: addresses,
 			InstanceType:  instanceType,
 			Zone:          vmRef.Node(),
@@ -192,6 +200,16 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 }
 
 func (i *instances) getInstance(node *v1.Node) (*pxapi.VmRef, string, error) {
+	if i.capi {
+		uuid := node.Status.NodeInfo.SystemUUID
+		vmRef, region, err := i.c.FindVMByUUID(uuid)
+		if err != nil {
+			return nil, "", fmt.Errorf("instances.getInstance() error: %v", err)
+		}
+
+		return vmRef, region, nil
+	}
+
 	vm, region, err := provider.ParseProviderID(node.Spec.ProviderID)
 	if err != nil {
 		return nil, "", fmt.Errorf("instances.getInstance() error: %v", err)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

This is currently a work in progress. What do you think of the general approach?
I did not yet find out how to pass the required flag to instances. Do you know how to accomplish this?

## What? (description)
This PR aims to add support for clusters managed by cluster api and the capmox infrastructure provider.

## Why? (reasoning)
See discussion in #163

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
