### PR TITLE
chore: clearer error message

### DIFF
--- a/pkg/proxmox/instances.go
+++ b/pkg/proxmox/instances.go
@@ -198,7 +198,10 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		}, nil
 	}
 
-	klog.InfoS("instances.InstanceMetadata() is kubelet has args: --cloud-provider=external on the node?", node, klog.KRef("", node.Name))
+	klog.InfoS(fmt.Sprintf(
+		"instances.InstanceMetadata() called: label %s missing from node. Was kubelet started without --cloud-provider=external?",
+		cloudproviderapi.AnnotationAlphaProvidedIPAddr),
+		node, klog.KRef("", node.Name))
 
 	return &cloudprovider.InstanceMetadata{}, nil
 }


### PR DESCRIPTION
Simple change to the error message when a node has no external IP address

Fixes #189

