### PR TITLE
feat: allow ccm to handle networking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,20 @@ linters:
     - intrange
     - noinlineerr
   settings:
+    importas:
+      alias:
+        - pkg: github.com/Telmate/proxmox-api-go/proxmox
+          alias: proxmoxapi
+        - pkg: github.com/sergelogvinov/proxmox-cloud-controller/manager/metrics
+          alias: metrics
+        - pkg: github.com/sergelogvinov/proxmox-cloud-controller/proxmoxpool
+          alias: proxmoxpool
+        - pkg: github.com/sergelogvinov/proxmox-cloud-controller/proxmox
+          alias: proxmox
+        - pkg: github.com/sergelogvinov/proxmox-cloud-controller/provider
+          alias: provider
+        - pkg: github.com/sergelogvinov/proxmox-cloud-controller/config
+          alias: providerconfig
     wsl_v5:
       allow-first-in-block: true
       allow-whole-block: false
@@ -69,7 +83,7 @@ linters:
     cyclop:
       max-complexity: 30
     dupl:
-      threshold: 100
+      threshold: 150
     errcheck:
       check-type-assertions: false
       check-blank: true

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,58 @@
+# Cloud controller manager configuration file
+
+This file is used to configure the Proxmox CCM.
+
+```yaml
+features:
+  # Provider type
+  provider: default|capmox
+  # Network mode
+  network: default|qemu|auto
+  # Enable or disable the IPv6 support
+  ipv6_support_disabled: true|false
+  # External IP address CIDRs list, comma-separated
+  # Use `!` to exclude a CIDR
+  external_ip_cidrs: '192.168.0.0/16,2001:db8:85a3::8a2e:370:7334/112,!fd00:1234:5678::/64'
+  # IP addresses sort order, comma-separated
+  # The IPs that do not match the CIDRs will be kept in the order they
+  # were detected.
+  ip_sort_order: '192.168.0.0/16,2001:db8:85a3::8a2e:370:7334/112'
+
+clusters:
+  # List of Proxmox clusters
+  - url: https://cluster-api-1.exmple.com:8006/api2/json
+    # Skip the certificate verification, if needed
+    insecure: false
+    # Proxmox api token
+    token_id: "kubernetes-csi@pve!csi"
+    token_secret: "secret"
+    # Region name, which is cluster name
+    region: Region-1
+
+  # Add more clusters if needed
+  - url: https://cluster-api-2.exmple.com:8006/api2/json
+    insecure: false
+    token_id: "kubernetes-csi@pve!csi"
+    token_secret: "secret"
+    region: Region-2
+```
+
+## Cluster list
+
+You can define multiple clusters in the `clusters` section.
+
+* `url` - The URL of the Proxmox cluster API.
+* `insecure` - Set to `true` to skip TLS certificate verification.
+* `token_id` - The Proxmox API token ID.
+* `token_secret` - The name of the Kubernetes Secret that contains the Proxmox API token.
+* `region` - The name of the region, which is also used as `topology.kubernetes.io/region` label.
+
+## Feature flags
+
+* `provider` - Set the provider type. The default is `default`, which uses provider-id to define the Proxmox VM ID. The `capmox` value is used for working with the Cluster API for Proxmox (CAPMox).
+* `network` - Defines how the network addresses are handled by the CCM. The default value is `default`, which uses the kubelet argument `--node-ips` to assign IPs to the node resource. The `qemu` mode uses the QEMU agent API to retrieve network addresses from the virtual machine, while auto attempts to detect the best mode automatically.
+* `ipv6_support_disabled` - Set to `true` to ignore any IPv6 addresses. The default is `false`.
+* `external_ip_cidrs` - A comma-separated list of external IP address CIDRs. You can use `!` to exclude a CIDR from the list. This is useful for defining which IPs should be considered external and not included in the node addresses.
+
+
+For more information about the network modes, see the [Networking documentation](networking.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -71,6 +71,8 @@ clusters:
     region: cluster-1
 ```
 
+See [configuration documentation](config.md) for more details.
+
 ### Method 1: kubectl
 
 Upload it to the kubernetes:

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,69 @@
+# Networking
+
+## Node Addressing modes
+
+There are three node addressing modes that Proxmox CCM supports:
+ - Default mode (only mode available till v0.9.0)
+ - Auto mode (available from vX.X.X)
+ - QEMU-only Mode
+
+In Default mode Proxmox CCM expects nodes to be provided with their private IP Address via the `--node-ip` kubelet flag. Default mode
+*does not* set the External IP of the node.
+
+In Auto mode, Proxmox CCM makes use of both the host-networking access (if available) and the QEMU guest agent API (if available) to determine the available IP Addresses. At a minimum Auto mode will set only the Internal IP addresses of the node but can be configured to know which IP Addresses should be treated as external based on provided CIDRs and what order ALL IP addresses should be sorted in according to a sort order CIDR.
+
+> [!NOTE]
+> All modes, including Default Mode, will use any IPs provided via the `alpha.kubernetes.io/provided-node-ip` annotation, unless they are part of the ignored cidrs list (non-default modes only).
+
+### Default Mode
+
+In Default Mode, Proxmox CCM assumes that the private IP of the node will be set using the kubelet arg `--node-ip`. Setting this flag adds an annotation to the node `alpha.kubernetes.io/provided-node-ip` which is used to then set the Node's `status.Addresses` field.
+
+In this mode there is no validation of the IP address.
+
+### Auto Mode
+
+In Auto mode, Proxmox CCM uses access to the QEMU guest agent API (if available) to get a list of interfaces and IP Addresses as well as any IP addresses provided via `--node-ip`. From there depending on configuration it will setup all detected addresses as private and set any addresses matching a configured set of external CIDRs as external.
+
+Enabling auto mode is done by setting the network feature mode to `auto`:
+
+```yaml
+features:
+  network:
+    mode: auto
+```
+
+### QEMU-only Mode
+
+In QEMU Mode, Proxmox CCM uses the QEMU guest agent API to retrieve a list of IP addresses and set them as Node Addresses. Any node addresses provided via the `alpha.kubernetes.io/provided-node-ip` node annotation will also be available.
+
+Enabling qemu-only mode is done by setting the network feature mode to `qemu`:
+
+```yaml
+features:
+  network:
+    mode: qemu
+```
+
+## Example configuration
+
+The following is example configuration which sets IP addresses from 192.168.0.1 - 192.168.255.254 and 2001:0db8:85a3:0000:0000:8a2e:0370:0000 - 2001:0db8:85a3:0000:0000:8a2e:0370:ffff as "external" addresses. All other IPs from subnet 10.0.0.0/8 will be ignored.
+
+To use any mode other than default specify the following configuration:
+
+```yaml
+features:
+  network:
+    mode: auto
+    external_ip_cidrs: '192.168.0.0/16,2001:db8:85a3::8a2e:370:7334/112,!10.0.0.0/8'
+```
+
+Further configuration options are available as well. We can disable ipv6 support entirely and provide an order to sort IP addresses in (with any that don't match just being kept in whatever order the make it into the list):
+
+```yaml
+features:
+  network:
+    mode: auto
+    ipv6_support_disabled: true
+    ip_sort_order: '192.168.0.0/16,2001:db8:85a3::8a2e:370:7334/112'
+```

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
 const (
@@ -34,7 +34,7 @@ const (
 var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
 
 // GetProviderID returns the magic providerID for kubernetes node.
-func GetProviderID(region string, vmr *pxapi.VmRef) string {
+func GetProviderID(region string, vmr *proxmox.VmRef) string {
 	return fmt.Sprintf("%s://%s/%d", ProviderName, region, vmr.VmId())
 }
 
@@ -63,7 +63,7 @@ func GetVMID(providerID string) (int, error) {
 }
 
 // ParseProviderID returns the VmRef and region from the providerID.
-func ParseProviderID(providerID string) (*pxapi.VmRef, string, error) {
+func ParseProviderID(providerID string) (*proxmox.VmRef, string, error) {
 	if !strings.HasPrefix(providerID, ProviderName) {
 		return nil, "", fmt.Errorf("foreign providerID or empty \"%s\"", providerID)
 	}
@@ -78,5 +78,5 @@ func ParseProviderID(providerID string) (*pxapi.VmRef, string, error) {
 		return nil, "", fmt.Errorf("InstanceID have to be a number, but got \"%s\"", matches[2])
 	}
 
-	return pxapi.NewVmRef(vmID), matches[1], nil
+	return proxmox.NewVmRef(vmID), matches[1], nil
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/stretchr/testify/assert"
 
 	provider "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/provider"
@@ -55,7 +55,7 @@ func TestGetProviderID(t *testing.T) {
 		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
 			t.Parallel()
 
-			providerID := provider.GetProviderID(testCase.region, pxapi.NewVmRef(testCase.vmID))
+			providerID := provider.GetProviderID(testCase.region, proxmox.NewVmRef(testCase.vmID))
 
 			assert.Equal(t, testCase.expectedProviderID, providerID)
 		})

--- a/pkg/proxmox/cloud.go
+++ b/pkg/proxmox/cloud.go
@@ -66,7 +66,7 @@ func newCloud(config *ccmConfig.ClustersConfig) (cloudprovider.Interface, error)
 		return nil, err
 	}
 
-	instancesInterface := newInstances(client, config.Features.Provider)
+	instancesInterface := newInstances(client, config.Features.Provider, config.Features.Network)
 
 	return &cloud{
 		client:      client,

--- a/pkg/proxmox/instance_addresses.go
+++ b/pkg/proxmox/instance_addresses.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+
+	providerconfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
+	metrics "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/metrics"
+
+	v1 "k8s.io/api/core/v1"
+	cloudproviderapi "k8s.io/cloud-provider/api"
+	"k8s.io/klog/v2"
+)
+
+const (
+	noSortPriority = 0
+)
+
+func (i *instances) addresses(ctx context.Context, node *v1.Node, vmRef *proxmox.VmRef, region string) []v1.NodeAddress {
+	klog.V(4).InfoS("instances.addresses() called", "node", klog.KObj(node))
+
+	var (
+		providedIP string
+		ok         bool
+	)
+
+	if providedIP, ok = node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr]; !ok {
+		klog.InfoS(fmt.Sprintf(
+			"instances.InstanceMetadata() called: annotation %s missing from node. Was kubelet started without --cloud-provider=external or --node-ip?",
+			cloudproviderapi.AnnotationAlphaProvidedIPAddr),
+			node, klog.KRef("", node.Name))
+	}
+
+	// providedIP is supposed to be a single IP but some kubelets might set a comma separated list of IPs.
+	providedAddresses := []string{}
+	if providedIP != "" {
+		providedAddresses = strings.Split(providedIP, ",")
+	}
+
+	addresses := []v1.NodeAddress{
+		{Type: v1.NodeHostName, Address: node.Name},
+	}
+
+	for _, address := range providedAddresses {
+		if address = strings.TrimSpace(address); address != "" {
+			parsedAddress := net.ParseIP(address)
+			if parsedAddress != nil {
+				addresses = append(addresses, v1.NodeAddress{
+					Type:    v1.NodeInternalIP,
+					Address: parsedAddress.String(),
+				})
+			} else {
+				klog.Warningf("Ignoring invalid provided address '%s' for node %s", address, node.Name)
+			}
+		}
+	}
+
+	if i.networkOpts.Mode == providerconfig.NetworkModeDefault {
+		// If the network mode is 'default', we only return the provided IPs.
+		klog.V(4).InfoS("instances.addresses() returning provided IPs", "node", klog.KObj(node))
+
+		return addresses
+	}
+
+	if i.networkOpts.Mode == providerconfig.NetworkModeOnlyQemu || i.networkOpts.Mode == providerconfig.NetworkModeAuto {
+		newAddresses, err := i.retrieveQemuAddresses(ctx, vmRef, region)
+		if err != nil {
+			klog.ErrorS(err, "Failed to retrieve host addresses")
+		} else {
+			addToNodeAddresses(&addresses, newAddresses...)
+		}
+	}
+
+	// Remove addresses that match the ignored CIDRs
+	if len(i.networkOpts.IgnoredCIDRs) > 0 {
+		var removableAddresses []v1.NodeAddress
+
+		for _, addr := range addresses {
+			ip := net.ParseIP(addr.Address)
+			if ip != nil && isAddressInCIDRList(i.networkOpts.IgnoredCIDRs, ip) {
+				removableAddresses = append(removableAddresses, addr)
+			}
+		}
+
+		removeFromNodeAddresses(&addresses, removableAddresses...)
+	}
+
+	sortNodeAddresses(addresses, i.networkOpts.SortOrder)
+
+	klog.InfoS("instances.addresses() returning addresses", "addresses", addresses, "node", klog.KObj(node))
+
+	return addresses
+}
+
+// retrieveQemuAddresses retrieves the addresses from the QEMU agent
+func (i *instances) retrieveQemuAddresses(ctx context.Context, vmRef *proxmox.VmRef, region string) ([]v1.NodeAddress, error) {
+	var addresses []v1.NodeAddress
+
+	klog.V(4).InfoS("retrieveQemuAddresses() retrieving addresses from QEMU agent")
+
+	r, err := i.getInstanceNics(ctx, vmRef, region)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, nic := range r {
+		for _, ip := range nic.IpAddresses {
+			i.processIP(ctx, &addresses, ip)
+		}
+	}
+
+	klog.V(4).InfoS("retrieveQemuAddresses() retrieved instance nics", "nics", r)
+
+	return addresses, nil
+}
+
+func (i *instances) processIP(_ context.Context, addresses *[]v1.NodeAddress, ip net.IP) {
+	if ip == nil || ip.IsLoopback() {
+		return
+	}
+
+	var isIPv6 bool
+
+	addressType := v1.NodeInternalIP
+
+	if isIPv6 = ip.To4() == nil; isIPv6 && i.networkOpts.IPv6SupportDisabled {
+		klog.V(4).InfoS("Skipping IPv6 address due to IPv6 support being disabled", "address", ip.String())
+
+		return // skip IPv6 addresses if IPv6 support is disabled
+	}
+
+	ipStr := ip.String()
+
+	// Check if the address is an external CIDR
+	if len(i.networkOpts.ExternalCIDRs) != 0 && isAddressInCIDRList(i.networkOpts.ExternalCIDRs, ip) {
+		addressType = v1.NodeExternalIP
+	}
+
+	*addresses = append(*addresses, v1.NodeAddress{
+		Type:    addressType,
+		Address: ipStr,
+	})
+}
+
+func (i *instances) getInstanceNics(ctx context.Context, vmRef *proxmox.VmRef, region string) ([]proxmox.AgentNetworkInterface, error) {
+	px, err := i.c.GetProxmoxCluster(region)
+	result := make([]proxmox.AgentNetworkInterface, 0)
+
+	if err != nil {
+		return result, err
+	}
+
+	mc := metrics.NewMetricContext("getVmInfo")
+	nicset, err := px.GetVmAgentNetworkInterfaces(ctx, vmRef)
+
+	if mc.ObserveRequest(err) != nil {
+		return result, err
+	}
+
+	klog.V(4).InfoS("getInstanceNics() retrieved IP set", "nicset", nicset)
+
+	return nicset, nil
+}
+
+// getSortPriority returns the priority as int of an address.
+//
+// The priority depends on the index of the CIDR in the list the address is matching,
+// where the first item of the list has higher priority than the last.
+//
+// If the address does not match any CIDR or is not an IP address the function returns noSortPriority.
+func getSortPriority(list []*net.IPNet, address string) int {
+	parsedAddress := net.ParseIP(address)
+	if parsedAddress == nil {
+		return noSortPriority
+	}
+
+	for i, cidr := range list {
+		if cidr.Contains(parsedAddress) {
+			return len(list) - i
+		}
+	}
+
+	return noSortPriority
+}
+
+// sortNodeAddresses sorts node addresses based on comma separated list of CIDRs represented by addressSortOrder.
+//
+// The function only sorts addresses which match the CIDR and leaves the other addresses in the same order they are in.
+// Essentially, it will also group the addresses matching a CIDR together and sort them ascending in this group,
+// whereas the inter-group sorting depends on the priority.
+//
+// The priority depends on the order of the item in addressSortOrder, where the first item has higher priority than the last.
+func sortNodeAddresses(addresses []v1.NodeAddress, addressSortOrder []*net.IPNet) {
+	sort.SliceStable(addresses, func(i int, j int) bool {
+		addressLeft := addresses[i]
+		addressRight := addresses[j]
+
+		priorityLeft := getSortPriority(addressSortOrder, addressLeft.Address)
+		priorityRight := getSortPriority(addressSortOrder, addressRight.Address)
+
+		// ignore priorities of value 0 since this means the address has noSortPriority and we need to sort by priority
+		if priorityLeft > noSortPriority && priorityLeft == priorityRight {
+			return bytes.Compare(net.ParseIP(addressLeft.Address), net.ParseIP(addressRight.Address)) < 0
+		}
+
+		return priorityLeft > priorityRight
+	})
+}
+
+// addToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
+// only if they do not already exist
+func addToNodeAddresses(addresses *[]v1.NodeAddress, addAddresses ...v1.NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+
+				break
+			}
+		}
+
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}
+
+// removeFromNodeAddresses removes the NodeAddresses from the passed-by-pointer
+// slice if they already exist.
+func removeFromNodeAddresses(addresses *[]v1.NodeAddress, removeAddresses ...v1.NodeAddress) {
+	var indexesToRemove []int
+
+	for _, remove := range removeAddresses {
+		for i := len(*addresses) - 1; i >= 0; i-- {
+			existing := (*addresses)[i]
+			if existing.Address == remove.Address && (existing.Type == remove.Type || remove.Type == "") {
+				indexesToRemove = append(indexesToRemove, i)
+			}
+		}
+	}
+
+	for _, i := range indexesToRemove {
+		if i < len(*addresses) {
+			*addresses = append((*addresses)[:i], (*addresses)[i+1:]...)
+		}
+	}
+}
+
+// isAddressInCIDRList checks if the given address is contained in any of the CIDRs in the list.
+func isAddressInCIDRList(cidrs []*net.IPNet, address net.IP) bool {
+	for _, cidr := range cidrs {
+		if cidr.Contains(address) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/proxmox/utils.go
+++ b/pkg/proxmox/utils.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"unicode"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// ErrorCIDRConflict is the error message formatting string for CIDR conflicts
+const ErrorCIDRConflict = "CIDR %s intersects with ignored CIDR %s"
+
+// SplitTrim splits a string of values separated by sep rune into a slice of
+// strings with trimmed spaces.
+func SplitTrim(s string, sep rune) []string {
+	f := func(c rune) bool {
+		return unicode.IsSpace(c) || c == sep
+	}
+
+	return strings.FieldsFunc(s, f)
+}
+
+// ParseCIDRRuleset parses a comma separated list of CIDRs and returns two slices of *net.IPNet, the first being the allow list, the second be the disallow list
+func ParseCIDRRuleset(cidrList string) (allowList, ignoreList []*net.IPNet, err error) {
+	cidrlist := SplitTrim(cidrList, ',')
+	if len(cidrlist) == 0 {
+		return []*net.IPNet{}, []*net.IPNet{}, nil
+	}
+
+	for _, item := range cidrlist {
+		isIgnore := false
+
+		if strings.HasPrefix(item, "!") {
+			item = strings.TrimPrefix(item, "!")
+			isIgnore = true
+		}
+
+		_, cidr, err := net.ParseCIDR(item)
+		if err != nil {
+			continue
+		}
+
+		if isIgnore {
+			ignoreList = append(ignoreList, cidr)
+
+			continue
+		}
+
+		allowList = append(allowList, cidr)
+	}
+
+	// Check for no interactions
+	for _, n1 := range allowList {
+		for _, n2 := range ignoreList {
+			if checkIPIntersects(n1, n2) {
+				return nil, nil, fmt.Errorf(ErrorCIDRConflict, n1.String(), n2.String())
+			}
+		}
+	}
+
+	return ignoreList, allowList, nil
+}
+
+// ParseCIDRList parses a comma separated list of CIDRs and returns a slice of *net.IPNet ignoring errors
+func ParseCIDRList(cidrList string) []*net.IPNet {
+	cidrlist := SplitTrim(cidrList, ',')
+	if len(cidrlist) == 0 {
+		return []*net.IPNet{}
+	}
+
+	cidrs := make([]*net.IPNet, 0, len(cidrlist))
+
+	for _, item := range cidrlist {
+		_, cidr, err := net.ParseCIDR(item)
+		if err != nil {
+			continue
+		}
+
+		cidrs = append(cidrs, cidr)
+	}
+
+	return cidrs
+}
+
+// HasTaintWithEffect checks if a node has a specific taint with the given key and effect.
+// An empty effect string will match any effect for the specified key
+func HasTaintWithEffect(node *v1.Node, key, effect string) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == key {
+			if effect != "" {
+				return string(taint.Effect) == effect
+			}
+
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkIPIntersects(n1, n2 *net.IPNet) bool {
+	return n2.Contains(n1.IP) || n1.Contains(n2.IP)
+}

--- a/pkg/proxmox/utils_test.go
+++ b/pkg/proxmox/utils_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	proxmox "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/proxmox"
+)
+
+func TestParseCIDRRuleset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		msg                string
+		cidrs              string
+		expectedAllowList  []*net.IPNet
+		expectedIgnoreList []*net.IPNet
+		expectedError      []interface{}
+	}{
+		{
+			msg:                "Empty CIDR ruleset",
+			cidrs:              "",
+			expectedAllowList:  []*net.IPNet{},
+			expectedIgnoreList: []*net.IPNet{},
+			expectedError:      []interface{}{},
+		},
+		{
+			msg:                "Conflicting CIDRs",
+			cidrs:              "192.168.0.1/16,!192.168.0.1/24",
+			expectedAllowList:  []*net.IPNet{},
+			expectedIgnoreList: []*net.IPNet{},
+			expectedError:      []interface{}{"192.168.0.0/16", "192.168.0.0/24"},
+		},
+		{
+			msg:                "Ignores invalid CIDRs",
+			cidrs:              "722.887.0.1/16,!588.0.1/24",
+			expectedAllowList:  []*net.IPNet{},
+			expectedIgnoreList: []*net.IPNet{},
+			expectedError:      []interface{}{},
+		},
+		{
+			msg:                "Valid CIDRs with ignore",
+			cidrs:              "192.168.0.1/16,!10.0.0.5/8,144.0.0.7/16,!13.0.0.9/8",
+			expectedAllowList:  []*net.IPNet{mustParseCIDR("192.168.0.0/16"), mustParseCIDR("144.0.0.0/16")},
+			expectedIgnoreList: []*net.IPNet{mustParseCIDR("10.0.0.0/8"), mustParseCIDR("13.0.0.0/8")},
+			expectedError:      []interface{}{},
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(fmt.Sprint(testCase.msg), func(t *testing.T) {
+			t.Parallel()
+
+			allowList, ignoreList, err := proxmox.ParseCIDRRuleset(testCase.cidrs)
+
+			assert.Equal(t, len(testCase.expectedAllowList), len(allowList), "Allow list length mismatch")
+			assert.Equal(t, len(testCase.expectedIgnoreList), len(ignoreList), "Allow list length mismatch")
+
+			if len(testCase.expectedError) != 0 {
+				assert.EqualError(t, err, fmt.Sprintf(proxmox.ErrorCIDRConflict, testCase.expectedError...), "Error mismatch")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+			}
+		})
+	}
+}
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, parsedCIDR, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse CIDR %s: %v", cidr, err))
+	}
+
+	return parsedCIDR
+}


### PR DESCRIPTION
# Ability to set node IPs via host networking or qemu agent

## What? (description)
As per #190 this allows for users to create network configuration so that proxmox ccm handles internal and external ip address assignment of nodes.

## Why? (reasoning)
In certain installations just as with systems like k0s, the `--node-ip` is not set by default and therefore no private IPs for new nodes are specified. This allows defining logic behind how to make that happen.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

## Changelog
Changes made:
 - Updated README.md to make it clear when talking about a proxmox cluster vs a kubernetes cluster
 - Updated metrics so we don't accidentally overwrite the global import
 - Added configuration to allow selecting a networking mode
 - Added validation for provided Ips via --node-ip
 - Added ability to retrieve ips for node via host networking
 - Added ability to choose ExternalIPs based on provided CIDRs
 - Updated tests to require the uninitialized taint
 - Updated tests to require hostname first
 - Updates conformance to threshold to default of 150 as tabled tests in instances_test.go were triggering
 - Added ability to set the sort order of addresses
 - Added ability to set CIDRs of addresses to ignore
 - Added documentation around how networking works
