### PR TITLE
refactor: split cloud config module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.16
 ########################################
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.4-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.5-alpine AS builder
 RUN apk update && apk add --no-cache make
 ENV GO111MODULE=on
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,11 @@ run: build ## Run
 lint: ## Lint Code
 	golangci-lint run --config .golangci.yml
 
+.PHONY: lint-fix
+lint-fix: ## Fix Lint Issues
+	golangci-lint run --fix --config .golangci.yml
+
+
 .PHONY: unit
 unit: ## Unit Tests
 	go test -tags=unit $(shell go list ./...) $(TESTARGS)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+// Package config is the configuration for the cloud provider.
+package config
 
 import (
 	"fmt"
@@ -24,6 +25,8 @@ import (
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
+
+	pxpool "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/proxmoxpool"
 )
 
 // Provider specifies the provider. Can be 'default' or 'capmox'
@@ -40,15 +43,7 @@ type ClustersConfig struct {
 	Features struct {
 		Provider Provider `yaml:"provider,omitempty"`
 	} `yaml:"features,omitempty"`
-	Clusters []struct {
-		URL         string `yaml:"url"`
-		Insecure    bool   `yaml:"insecure,omitempty"`
-		TokenID     string `yaml:"token_id,omitempty"`
-		TokenSecret string `yaml:"token_secret,omitempty"`
-		Username    string `yaml:"username,omitempty"`
-		Password    string `yaml:"password,omitempty"`
-		Region      string `yaml:"region,omitempty"`
-	} `yaml:"clusters,omitempty"`
+	Clusters []*pxpool.ProxmoxCluster `yaml:"clusters,omitempty"`
 }
 
 // ReadCloudConfig reads cloud config from a reader.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster_test
+package config_test
 
 import (
 	"strings"
@@ -22,23 +22,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/cluster"
+	ccmConfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
 )
 
 func TestReadCloudConfig(t *testing.T) {
-	cfg, err := cluster.ReadCloudConfig(nil)
+	cfg, err := ccmConfig.ReadCloudConfig(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 
 	// Empty config
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
 `))
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 
 	// Wrong config
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
   test: false
 `))
@@ -47,7 +47,7 @@ clusters:
 	assert.NotNil(t, cfg)
 
 	// Non full config
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
 - url: abcd
   region: cluster-1
@@ -57,7 +57,7 @@ clusters:
 	assert.NotNil(t, cfg)
 
 	// Valid config with one cluster
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
   - url: https://example.com
     insecure: false
@@ -70,7 +70,7 @@ clusters:
 	assert.Equal(t, 1, len(cfg.Clusters))
 
 	// Valid config with one cluster (username/password), implicit default provider
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
   - url: https://example.com
     insecure: false
@@ -81,10 +81,10 @@ clusters:
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 1, len(cfg.Clusters))
-	assert.Equal(t, cluster.ProviderDefault, cfg.Features.Provider)
+	assert.Equal(t, ccmConfig.ProviderDefault, cfg.Features.Provider)
 
 	// Valid config with one cluster (username/password), explicit provider default
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 features:
   provider: 'default'
 clusters:
@@ -97,10 +97,10 @@ clusters:
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 1, len(cfg.Clusters))
-	assert.Equal(t, cluster.ProviderDefault, cfg.Features.Provider)
+	assert.Equal(t, ccmConfig.ProviderDefault, cfg.Features.Provider)
 
 	// Valid config with one cluster (username/password), explicit provider capmox
-	cfg, err = cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err = ccmConfig.ReadCloudConfig(strings.NewReader(`
 features:
   provider: 'capmox'
 clusters:
@@ -113,16 +113,16 @@ clusters:
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 1, len(cfg.Clusters))
-	assert.Equal(t, cluster.ProviderCapmox, cfg.Features.Provider)
+	assert.Equal(t, ccmConfig.ProviderCapmox, cfg.Features.Provider)
 }
 
 func TestReadCloudConfigFromFile(t *testing.T) {
-	cfg, err := cluster.ReadCloudConfigFromFile("testdata/cloud-config.yaml")
+	cfg, err := ccmConfig.ReadCloudConfigFromFile("testdata/cloud-config.yaml")
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "error reading testdata/cloud-config.yaml: open testdata/cloud-config.yaml: no such file or directory")
 	assert.NotNil(t, cfg)
 
-	cfg, err = cluster.ReadCloudConfigFromFile("../../hack/proxmox-config.yaml")
+	cfg, err = ccmConfig.ReadCloudConfigFromFile("../../hack/proxmox-config.yaml")
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 2, len(cfg.Clusters))

--- a/pkg/proxmox/cloud.go
+++ b/pkg/proxmox/cloud.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/cluster"
+	ccmConfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
 	provider "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/provider"
+	pxpool "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/proxmoxpool"
 
 	clientkubernetes "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
@@ -38,7 +39,7 @@ const (
 )
 
 type cloud struct {
-	client      *cluster.Cluster
+	client      *pxpool.ProxmoxPool
 	kclient     clientkubernetes.Interface
 	instancesV2 cloudprovider.InstancesV2
 
@@ -48,7 +49,7 @@ type cloud struct {
 
 func init() {
 	cloudprovider.RegisterCloudProvider(provider.ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		cfg, err := cluster.ReadCloudConfig(config)
+		cfg, err := ccmConfig.ReadCloudConfig(config)
 		if err != nil {
 			klog.ErrorS(err, "failed to read config")
 
@@ -59,8 +60,8 @@ func init() {
 	})
 }
 
-func newCloud(config *cluster.ClustersConfig) (cloudprovider.Interface, error) {
-	client, err := cluster.NewCluster(config, nil)
+func newCloud(config *ccmConfig.ClustersConfig) (cloudprovider.Interface, error) {
+	client, err := pxpool.NewProxmoxPool(config.Clusters, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxmox/cloud_test.go
+++ b/pkg/proxmox/cloud_test.go
@@ -22,19 +22,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/cluster"
+	ccmConfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
 	provider "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/provider"
 )
 
 func TestNewCloudError(t *testing.T) {
-	cloud, err := newCloud(&cluster.ClustersConfig{})
+	cloud, err := newCloud(&ccmConfig.ClustersConfig{})
 	assert.NotNil(t, err)
 	assert.Nil(t, cloud)
 	assert.EqualError(t, err, "no Proxmox clusters found")
 }
 
 func TestCloud(t *testing.T) {
-	cfg, err := cluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err := ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
   - url: https://example.com
     insecure: false

--- a/pkg/proxmox/instances_test.go
+++ b/pkg/proxmox/instances_test.go
@@ -28,8 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	proxmoxcluster "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/cluster"
+	ccmConfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
 	"github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/provider"
+	pxpool "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/proxmoxpool"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +45,7 @@ type ccmTestSuite struct {
 }
 
 func (ts *ccmTestSuite) SetupTest() {
-	cfg, err := proxmoxcluster.ReadCloudConfig(strings.NewReader(`
+	cfg, err := ccmConfig.ReadCloudConfig(strings.NewReader(`
 clusters:
 - url: https://127.0.0.1:8006/api2/json
   insecure: false
@@ -171,12 +172,12 @@ clusters:
 		},
 	)
 
-	cluster, err := proxmoxcluster.NewCluster(&cfg, &http.Client{})
+	cluster, err := pxpool.NewProxmoxPool(cfg.Clusters, &http.Client{})
 	if err != nil {
 		ts.T().Fatalf("failed to create cluster client: %v", err)
 	}
 
-	ts.i = newInstances(cluster, proxmoxcluster.ProviderDefault)
+	ts.i = newInstances(cluster, ccmConfig.ProviderDefault)
 }
 
 func (ts *ccmTestSuite) TearDownTest() {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

We will split the cloud configuration into two parts:
  the original cloud controller configuration and a separate function for working with multiple Proxmox clusters.

## Why? (reasoning)

need to https://github.com/sergelogvinov/proxmox-cloud-controller-manager/pull/205

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
