### PR TITLE
feat: add named errors to cloud config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,6 +44,7 @@ clusters:
 `))
 
 	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, providerconfig.ErrInvalidCloudConfig)
 	assert.NotNil(t, cfg)
 
 	// Non full config
@@ -54,6 +55,7 @@ clusters:
 `))
 
 	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, providerconfig.ErrAuthCredentialsMissing)
 	assert.NotNil(t, cfg)
 
 	// Valid config with one cluster
@@ -142,6 +144,7 @@ clusters:
     password: "secret"
 `))
 	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, providerconfig.ErrMissingPVERegion)
 
 	// Errors when empty url
 	_, err = providerconfig.ReadCloudConfig(strings.NewReader(`
@@ -155,6 +158,7 @@ clusters:
     password: "secret"
 `))
 	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, providerconfig.ErrMissingPVEAPIURL)
 
 	// Errors when invalid url protocol
 	_, err = providerconfig.ReadCloudConfig(strings.NewReader(`
@@ -168,6 +172,7 @@ clusters:
     password: "secret"
 `))
 	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, providerconfig.ErrMissingPVEAPIURL)
 }
 
 func TestNetworkConfig(t *testing.T) {


### PR DESCRIPTION
## What? (description)
Changes errors created by cloud config to be standardised so that any other packages relying on the cloud config can check if the error is of the same "type".

Begins to address #212 

## Why? (reasoning)
It allows for more verbose testing (you can double check that the error message contains an expected string with the golang builtins with the `errors` package) and allows other packages relying on the package to follow errors even if the underlying error string changes.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)
