### PR TITLE
feat: add extra labels

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -52,7 +52,7 @@ You can define multiple clusters in the `clusters` section.
 
 ## Feature flags
 
-* `provider` - Set the provider type. The default is `default`, which uses provider-id to define the Proxmox VM ID. The `capmox` value is used for working with the Cluster API for Proxmox (CAPMox).
+* `provider` - Set the provider type. The default is `default`, which uses provider-id format `proxmox://<region>/<vm-id>`. The `capmox` value is used for working with the Cluster API for Proxmox (CAPMox), which uses provider-id format `proxmox://<SystemUUID>`.
 * `network` - Defines how the network addresses are handled by the CCM. The default value is `default`, which uses the kubelet argument `--node-ips` to assign IPs to the node resource. The `qemu` mode uses the QEMU agent API to retrieve network addresses from the virtual machine, while auto attempts to detect the best mode automatically.
 * `ipv6_support_disabled` - Set to `true` to ignore any IPv6 addresses. The default is `false`.
 * `external_ip_cidrs` - A comma-separated list of external IP address CIDRs. You can use `!` to exclude a CIDR from the list. This is useful for defining which IPs should be considered external and not included in the node addresses.

--- a/pkg/proxmox/instances_test.go
+++ b/pkg/proxmox/instances_test.go
@@ -574,6 +574,10 @@ func (ts *ccmTestSuite) TestInstanceMetadata() {
 				InstanceType: "4VCPU-10GB",
 				Region:       "cluster-1",
 				Zone:         "pve-1",
+				AdditionalLabels: map[string]string{
+					"topology.proxmox.sinextra.dev/node":   "pve-1",
+					"topology.proxmox.sinextra.dev/region": "cluster-1",
+				},
 			},
 		},
 		{
@@ -619,6 +623,10 @@ func (ts *ccmTestSuite) TestInstanceMetadata() {
 				InstanceType: "4VCPU-10GB",
 				Region:       "cluster-1",
 				Zone:         "pve-1",
+				AdditionalLabels: map[string]string{
+					"topology.proxmox.sinextra.dev/node":   "pve-1",
+					"topology.proxmox.sinextra.dev/region": "cluster-1",
+				},
 			},
 		},
 		{
@@ -660,6 +668,10 @@ func (ts *ccmTestSuite) TestInstanceMetadata() {
 				InstanceType: "c1.medium",
 				Region:       "cluster-2",
 				Zone:         "pve-3",
+				AdditionalLabels: map[string]string{
+					"topology.proxmox.sinextra.dev/node":   "pve-3",
+					"topology.proxmox.sinextra.dev/region": "cluster-2",
+				},
 			},
 		},
 	}

--- a/pkg/proxmox/labels.go
+++ b/pkg/proxmox/labels.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+const (
+	// LabelTopologyRegion is the label used to store the Proxmox region name.
+	LabelTopologyRegion = "topology." + Group + "/region"
+
+	// LabelTopologyZone is the label used to store the Proxmox zone name.
+	LabelTopologyZone = "topology." + Group + "/zone"
+
+	// LabelTopologyNode is the label used to store the Proxmox node name.
+	LabelTopologyNode = "topology." + Group + "/node"
+
+	// LabelTopologyHAGroup is the label used to store the Proxmox HA group name.
+	LabelTopologyHAGroup = "topology." + Group + "/ha-group"
+)


### PR DESCRIPTION
Add labels:
* topology.proxmox.sinextra.dev/node
* topology.proxmox.sinextra.dev/region

These labels represent the default topology labels. They make it possible to use different topologies on the Proxmox side.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
