### PR TITLE
feat: enhance ha-group handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ metadata:
     # Proxmox specific labels
     topology.proxmox.sinextra.dev/region: cluster-1
     topology.proxmox.sinextra.dev/zone: pve-node-1
-    topology.proxmox.sinextra.dev/ha-group: default
+    # HA group labels - the same idea as node-role
+    group.topology.proxmox.sinextra.dev/${HAGroup}: ""
 
   name: worker-1
 spec:

--- a/pkg/proxmox/instances_test.go
+++ b/pkg/proxmox/instances_test.go
@@ -665,8 +665,9 @@ func (ts *configuredTestSuite) TestInstanceMetadata() {
 				Region:       "cluster-1",
 				Zone:         "pve-1",
 				AdditionalLabels: map[string]string{
-					"topology.proxmox.sinextra.dev/region": "cluster-1",
-					"topology.proxmox.sinextra.dev/zone":   "pve-1",
+					"group.topology.proxmox.sinextra.dev/rnd": "",
+					"topology.proxmox.sinextra.dev/region":    "cluster-1",
+					"topology.proxmox.sinextra.dev/zone":      "pve-1",
 				},
 			},
 		},
@@ -717,8 +718,9 @@ func (ts *configuredTestSuite) TestInstanceMetadata() {
 				Region:       "cluster-1",
 				Zone:         "pve-1",
 				AdditionalLabels: map[string]string{
-					"topology.proxmox.sinextra.dev/region": "cluster-1",
-					"topology.proxmox.sinextra.dev/zone":   "pve-1",
+					"group.topology.proxmox.sinextra.dev/rnd": "",
+					"topology.proxmox.sinextra.dev/region":    "cluster-1",
+					"topology.proxmox.sinextra.dev/zone":      "pve-1",
 				},
 			},
 		},

--- a/pkg/proxmox/labels.go
+++ b/pkg/proxmox/labels.go
@@ -23,6 +23,6 @@ const (
 	// LabelTopologyZone is the label used to store the Proxmox zone name.
 	LabelTopologyZone = "topology." + Group + "/zone"
 
-	// LabelTopologyHAGroup is the label used to store the Proxmox HA group name.
-	LabelTopologyHAGroup = "topology." + Group + "/ha-group"
+	// LabelTopologyHAGroupPrefix is the prefix for labels used to store Proxmox HA group information.
+	LabelTopologyHAGroupPrefix = "group.topology." + Group + "/"
 )

--- a/test/cluster/cluster.go
+++ b/test/cluster/cluster.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/luthermonson/go-proxmox"
+
+	goproxmox "github.com/sergelogvinov/go-proxmox"
 )
 
 // SetupMockResponders sets up the HTTP mock responders for Proxmox API calls.
@@ -36,6 +38,15 @@ func SetupMockResponders() {
 		func(_ *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(200, map[string]any{
 				"data": proxmox.NodeStatuses{{Name: "pve-1"}, {Name: "pve-2"}, {Name: "pve-3"}, {Name: "pve-4"}},
+			})
+		})
+	httpmock.RegisterResponder(http.MethodGet, `=~/cluster/ha/groups`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"data": []goproxmox.HAGroup{
+					{Group: "rnd", Type: "group", Nodes: "pve-1,pve-2"},
+					{Group: "dev", Type: "group", Nodes: "pve-4"},
+				},
 			})
 		})
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Add the `group.topology.proxmox.sinextra.dev/${ha-group}` label to improve support for node selector and affinity rules.

## Why? (reasoning)

#130

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple high-availability (HA) groups per node, replacing the previous single-group limitation.

* **Bug Fixes**
  * Improved error handling and logging when parsing provider IDs from node metadata.
  * Enhanced fallback mechanisms for locating nodes in the cluster.

* **Documentation**
  * Updated configuration examples to reflect the new HA group label structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->