### PR TITLE
fix: ha-groups

### DIFF
--- a/pkg/proxmox/instances.go
+++ b/pkg/proxmox/instances.go
@@ -250,8 +250,6 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 	if err != nil {
 		if !errors.Is(err, proxmoxpool.ErrHAGroupNotFound) {
 			klog.ErrorS(err, "instances.InstanceMetadata() failed to get HA group for the node", "node", klog.KRef("", node.Name), "region", info.Region)
-
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Proxmox 9 uses HA rules instead of HA groups.
Do not treat it as an error if the HA group (used in Proxmox 8) cannot be retrieved.

## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-csi-plugin/issues/472

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for HA group retrieval to be more resilient. The system now gracefully continues processing when encountering non-critical errors, allowing instance metadata and labeling to complete successfully even if certain HA group information cannot be fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->