### PR TITLE
fix: service account name

### DIFF
--- a/charts/proxmox-cloud-controller-manager/Chart.yaml
+++ b/charts/proxmox-cloud-controller-manager/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.24
+version: 0.2.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
@@ -71,8 +71,12 @@ spec:
           {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.extraEnvs }}
           env:
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+          {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/pkg/proxmox/cloud.go
+++ b/pkg/proxmox/cloud.go
@@ -20,6 +20,7 @@ package proxmox
 import (
 	"context"
 	"io"
+	"os"
 
 	ccmConfig "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/config"
 	provider "github.com/sergelogvinov/proxmox-cloud-controller-manager/pkg/provider"
@@ -36,6 +37,8 @@ const (
 
 	// ServiceAccountName is the service account name used in kube-system namespace.
 	ServiceAccountName = provider.ProviderName + "-cloud-controller-manager"
+	// ServiceAccountNameEnv is the environment variable for the service account name.
+	ServiceAccountNameEnv = "SERVICE_ACCOUNT"
 
 	// Group name
 	Group = "proxmox.sinextra.dev"
@@ -96,7 +99,12 @@ func newCloud(config *ccmConfig.ClustersConfig) (cloudprovider.Interface, error)
 // to perform housekeeping or run custom controllers specific to the cloud provider.
 // Any tasks started here should be cleaned up when the stop channel closes.
 func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
-	c.client.kclient = clientBuilder.ClientOrDie(ServiceAccountName)
+	serviceAccountName := os.Getenv(ServiceAccountNameEnv)
+	if serviceAccountName == "" {
+		serviceAccountName = ServiceAccountName
+	}
+
+	c.client.kclient = clientBuilder.ClientOrDie(serviceAccountName)
 
 	klog.InfoS("clientset initialized")
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Redefine the default service account name using environment variables.

## Why? (reasoning)

fix: #274 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic service account configuration via the SERVICE_ACCOUNT environment variable, enabling flexible deployment scenarios while maintaining backward compatibility with default values.

* **Chores**
  * Updated chart version to 0.2.25.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->