### PR TITLE
fix: deployment templating and values comments

### DIFF
--- a/charts/proxmox-cloud-controller-manager/Chart.yaml
+++ b/charts/proxmox-cloud-controller-manager/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.25
+version: 0.2.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-cloud-controller-manager/README.md
+++ b/charts/proxmox-cloud-controller-manager/README.md
@@ -1,6 +1,6 @@
 # proxmox-cloud-controller-manager
 
-![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.3](https://img.shields.io/badge/AppVersion-v0.12.3-informational?style=flat-square)
+![Version: 0.2.26](https://img.shields.io/badge/Version-0.2.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.3](https://img.shields.io/badge/AppVersion-v0.12.3-informational?style=flat-square)
 
 Cloud Controller Manager plugin for Proxmox
 
@@ -136,8 +136,8 @@ helm upgrade -i --namespace=kube-system -f proxmox-ccm.yaml \
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
-| extraEnvs | list | `[]` | Any extra environments for talos-cloud-controller-manager |
-| extraArgs | list | `[]` | Any extra arguments for talos-cloud-controller-manager |
+| extraEnvs | list | `[]` | Any extra environments for proxmox-cloud-controller-manager |
+| extraArgs | list | `[]` | Any extra arguments for proxmox-cloud-controller-manager |
 | enabledControllers | list | `["cloud-node","cloud-node-lifecycle"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node,cloud-node-lifecycle` controllers. |
 | logVerbosityLevel | int | `2` | Log verbosity level. See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md for description of individual verbosity levels. |
 | existingConfigSecret | string | `nil` | Proxmox cluster config stored in secrets. |

--- a/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
@@ -14,9 +14,17 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: {{ .Values.updateStrategy.type }}
+    {{- if and (eq .Values.updateStrategy.type "RollingUpdate") .Values.updateStrategy.rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .Values.updateStrategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   {{- else }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
+    {{- if and (eq .Values.updateStrategy.type "RollingUpdate") .Values.updateStrategy.rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .Values.updateStrategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -52,7 +60,10 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers: {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/proxmox-cloud-controller-manager/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.yaml
@@ -16,13 +16,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# -- Any extra environments for talos-cloud-controller-manager
+# -- Any extra environments for proxmox-cloud-controller-manager
 extraEnvs:
   []
   # - name: KUBERNETES_SERVICE_HOST
   #   value: 127.0.0.1
 
-# -- Any extra arguments for talos-cloud-controller-manager
+# -- Any extra arguments for proxmox-cloud-controller-manager
 extraArgs:
   []
   # - --cluster-name=kubernetes

--- a/docs/deploy/cloud-controller-manager-daemonset.yml
+++ b/docs/deploy/cloud-controller-manager-daemonset.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -106,7 +106,7 @@ kind: DaemonSet
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -115,6 +115,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: proxmox-cloud-controller-manager
@@ -138,8 +140,6 @@ spec:
         runAsUser: 10258
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
-      initContainers:
-        []
       containers:
         - name: proxmox-cloud-controller-manager
           securityContext:
@@ -149,7 +149,7 @@ spec:
               - ALL
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.12.3"
+          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.13.0"
           imagePullPolicy: IfNotPresent
           args:
             - --v=2
@@ -160,6 +160,11 @@ spec:
             - --use-service-account-credentials
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          env:
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - name: metrics
               containerPort: 10258

--- a/docs/deploy/cloud-controller-manager-talos.yml
+++ b/docs/deploy/cloud-controller-manager-talos.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -116,6 +116,8 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: proxmox-cloud-controller-manager
@@ -137,8 +139,6 @@ spec:
         runAsGroup: 10258
         runAsNonRoot: true
         runAsUser: 10258
-      initContainers:
-        []
       containers:
         - name: proxmox-cloud-controller-manager
           securityContext:
@@ -148,7 +148,7 @@ spec:
               - ALL
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.12.3"
+          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.13.0"
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -159,6 +159,11 @@ spec:
             - --use-service-account-credentials
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          env:
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - name: metrics
               containerPort: 10258

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: proxmox-cloud-controller-manager
   labels:
-    helm.sh/chart: proxmox-cloud-controller-manager-0.2.23
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.26
     app.kubernetes.io/name: proxmox-cloud-controller-manager
     app.kubernetes.io/instance: proxmox-cloud-controller-manager
     app.kubernetes.io/version: "v0.12.3"
@@ -116,6 +116,8 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: proxmox-cloud-controller-manager
@@ -137,8 +139,6 @@ spec:
         runAsGroup: 10258
         runAsNonRoot: true
         runAsUser: 10258
-      initContainers:
-        []
       containers:
         - name: proxmox-cloud-controller-manager
           securityContext:
@@ -148,7 +148,7 @@ spec:
               - ALL
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.12.3"
+          image: "ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.13.0"
           imagePullPolicy: Always
           args:
             - --v=4
@@ -159,6 +159,11 @@ spec:
             - --use-service-account-credentials
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          env:
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - name: metrics
               containerPort: 10258


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Make use of `updateStrategy.rollingUpdate` values and make `initContainers` conditional.

Couple comments that mention talos (I suppose it should be proxmox?).

## Why? (reasoning)

When `initContainers` is `[]` (the default), this renders as `initContainers: []`. That's valid but doesn't follow the pattern of this chart. Also, if the value were null, it would render `initContainers: null` which could cause issues on some Kubernetes versions. 

`updateStrategy.rollingUpdate` is defined in values but never used.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`) run errors
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rolling-update and init container blocks are now emitted only when configured; empty initContainers removed.
  * Chart and container versions bumped (chart 0.2.26, app image v0.13.0).
  * Deployments/DaemonSets add rollingUpdate maxUnavailable: 1 and a SERVICE_ACCOUNT env var sourced from the pod spec.

* **Documentation**
  * Helm values and README badges/descriptions updated to reflect current naming and versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->