### PR TITLE
fix: case-insensitivity uuid

### DIFF
--- a/pkg/proxmox/instances.go
+++ b/pkg/proxmox/instances.go
@@ -369,7 +369,7 @@ func (i *instances) getInstanceInfo(ctx context.Context, node *v1.Node) (*instan
 		Zone:   vm.Node,
 	}
 
-	if info.UUID != node.Status.NodeInfo.SystemUUID {
+	if !strings.EqualFold(info.UUID, node.Status.NodeInfo.SystemUUID) {
 		klog.Errorf("instances.getInstanceInfo() node %s does not match SystemUUID=%s", info.Name, node.Status.NodeInfo.SystemUUID)
 
 		return nil, cloudprovider.InstanceNotFound

--- a/pkg/proxmoxpool/pool.go
+++ b/pkg/proxmoxpool/pool.go
@@ -249,7 +249,7 @@ func (c *ProxmoxPool) FindVMByNode(ctx context.Context, node *v1.Node) (vmID int
 				return false, err
 			}
 
-			if goproxmox.GetVMUUID(vm) == node.Status.NodeInfo.SystemUUID {
+			if strings.EqualFold(goproxmox.GetVMUUID(vm), node.Status.NodeInfo.SystemUUID) {
 				return true, nil
 			}
 
@@ -298,7 +298,7 @@ func (c *ProxmoxPool) FindVMByUUID(ctx context.Context, uuid string) (vmID int, 
 				return false, err
 			}
 
-			if goproxmox.GetVMUUID(vm) == uuid {
+			if strings.EqualFold(goproxmox.GetVMUUID(vm), uuid) {
 				return true, nil
 			}
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Some Windows machines expose the UUID in uppercase. 
We need to perform case-insensitive comparisons when matching it.

## Why? (reasoning)

close #288

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VM instance matching to use case-insensitive UUID comparison, improving reliability of VM identification in Proxmox environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->