### PR TITLE
feat(chart): allow customizing DNS policy

### DIFF
--- a/charts/proxmox-cloud-controller-manager/Chart.yaml
+++ b/charts/proxmox-cloud-controller-manager/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.27
+version: 0.2.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-cloud-controller-manager/ci/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/ci/values.yaml
@@ -13,6 +13,9 @@ affinity:
 
 logVerbosityLevel: 4
 
+# useDaemonSet: true
+# dnsPolicy: ClusterFirstWithHostNet
+
 extraEnvs:
   - name: KUBERNETES_SERVICE_HOST
     value: 127.0.0.1

--- a/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/proxmox-cloud-controller-manager/templates/deployment.yaml
@@ -53,8 +53,10 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.useDaemonSet }}
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ default "ClusterFirstWithHostNet" .Values.dnsPolicy }}
       hostNetwork: true
+      {{- else if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:

--- a/charts/proxmox-cloud-controller-manager/values.yaml
+++ b/charts/proxmox-cloud-controller-manager/values.yaml
@@ -146,6 +146,11 @@ resources:
 # It allows to use CCM without CNI plugins.
 useDaemonSet: false
 
+# -- Specifies the DNS policy for the controller
+# Default is ClusterFirstWithHostNet for DaemonSet mode, and ClusterFirst for Deployment mode.
+# ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: ""
+
 # -- Deployment update strategy type.
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment
 updateStrategy:


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Proxmox CCM will first have to approve the PR.
-->

## What? (description)

Add the ability to override the default dnsPolicy configuration.
## Why? (reasoning)

https://github.com/sergelogvinov/proxmox-cloud-controller-manager/issues/300

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS policy settings for the controller are now configurable, with environment-specific defaults for DaemonSet and Deployment modes.

* **Chores**
  * Updated Helm chart version to 0.2.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->