### PR TITLE
fix: use ha rules as ha groups on proxmox 9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,3 +129,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/sergelogvinov/go-proxmox => github.com/the-veloper/go-proxmox v0.2.1-0.20260713234836-6f6afa628907

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/sergelogvinov/go-proxmox v0.2.0 h1:WeYrylh2Ovc/hGo0hc99xyycjchxeZ6pxmaPvGyqxzQ=
-github.com/sergelogvinov/go-proxmox v0.2.0/go.mod h1:aBAwXyypY//9m2/CPRVtajV0SWBVq7eYlcwiSxoNSFU=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
@@ -194,6 +192,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/the-veloper/go-proxmox v0.2.1-0.20260713234836-6f6afa628907 h1:uSke6GEiPFalnPc75MTJkANaAjxYoO4oIC+5b0q51NM=
+github.com/the-veloper/go-proxmox v0.2.1-0.20260713234836-6f6afa628907/go.mod h1:aBAwXyypY//9m2/CPRVtajV0SWBVq7eYlcwiSxoNSFU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=

--- a/pkg/proxmoxpool/pool.go
+++ b/pkg/proxmoxpool/pool.go
@@ -200,7 +200,26 @@ func (c *ProxmoxPool) GetNodeHAGroups(ctx context.Context, region string, node s
 
 	haGroups, err := px.GetHAGroupList(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error get ha-groups %v", err)
+		// Proxmox VE 9 migrated HA groups to HA rules, the ha-groups endpoint
+		// fails there with "ha groups have been migrated to rules".
+		// Node affinity rules keep the same node list format as groups,
+		// so use them as HA groups.
+		haRules, rulesErr := px.GetHARuleList(ctx)
+		if rulesErr != nil {
+			return nil, fmt.Errorf("error get ha-groups %v", err)
+		}
+
+		for _, r := range haRules {
+			if r.Type != "node-affinity" || (r.Disable != nil && bool(*r.Disable)) {
+				continue
+			}
+
+			for n := range strings.SplitSeq(r.Nodes, ",") {
+				if node == strings.Split(n, ":")[0] {
+					groups = append(groups, r.Rule)
+				}
+			}
+		}
 	}
 
 	for _, g := range haGroups {

--- a/pkg/proxmoxpool/pool_test.go
+++ b/pkg/proxmoxpool/pool_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package proxmoxpool_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -116,4 +119,70 @@ func TestCheckClusters(t *testing.T) {
 	err = pxClient.CheckClusters(t.Context())
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "failed to initialized proxmox client in region")
+}
+
+func TestGetNodeHAGroups(t *testing.T) {
+	pve8 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/json/cluster/ha/groups":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"data":[
+				{"group":"gpu-nodes","type":"group","nodes":"pve1:2,pve2"},
+				{"group":"storage-nodes","type":"group","nodes":"pve3"}
+			]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer pve8.Close()
+
+	// Proxmox VE 9 migrated HA groups to HA rules
+	pve9 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/json/cluster/ha/groups":
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintln(w, `{"data":null,"message":"cannot index groups: ha groups have been migrated to rules"}`)
+		case "/api2/json/cluster/ha/rules":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"data":[
+				{"rule":"gpu-nodes","type":"node-affinity","nodes":"pve1:2,pve2","resources":"vm:100","strict":0},
+				{"rule":"disabled-rule","type":"node-affinity","nodes":"pve1","disable":1},
+				{"rule":"keep-apart","type":"resource-affinity","resources":"vm:100,vm:101"}
+			]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer pve9.Close()
+
+	for _, tt := range []struct {
+		name string
+		url  string
+	}{
+		{name: "ha-groups", url: pve8.URL},
+		{name: "ha-rules", url: pve9.URL},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := []*pxpool.ProxmoxCluster{
+				{
+					URL:         tt.url + "/api2/json",
+					TokenID:     "user!token-id",
+					TokenSecret: "secret",
+					Region:      "cluster-1",
+				},
+			}
+
+			pxClient, err := pxpool.NewProxmoxPool(cfg)
+			assert.Nil(t, err)
+			assert.NotNil(t, pxClient)
+
+			groups, err := pxClient.GetNodeHAGroups(t.Context(), "cluster-1", "pve1")
+			assert.Nil(t, err)
+			assert.Equal(t, []string{"gpu-nodes"}, groups)
+
+			groups, err = pxClient.GetNodeHAGroups(t.Context(), "cluster-1", "pve5")
+			assert.Equal(t, pxpool.ErrHAGroupNotFound, err)
+			assert.Nil(t, groups)
+		})
+	}
 }


### PR DESCRIPTION
## What? (description)

On Proxmox VE 9, `GetNodeHAGroups` falls back to reading `/cluster/ha/rules` and treats enabled `node-affinity` rules as HA groups.

## Why? (reasoning)

Proxmox VE 9 migrated HA groups to HA node affinity rules, so the `/cluster/ha/groups` endpoint fails with `cannot index groups: ha groups have been migrated to rules` and the CCM logs this error for every node on each metadata sync (#266).

Node affinity rules keep the same `node[:priority]` list format that groups had, and PVE 9 migrates legacy group definitions to rules with the same names, so both the `ha-group.proxmox.sergelogvinov.github.io/<name>` labels and the `features.ha_group` zone mapping keep working unchanged on PVE 9.

**Depends on sergelogvinov/go-proxmox#22** adding `GetHARuleList` — the `go.mod` `replace` pointing at my fork is temporary so CI can build; I'll drop it and bump the dependency once that PR is merged/released.

Fixes #266

## Acceptance

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable) — `TestGetNodeHAGroups` covers both the PVE 8 groups path and the PVE 9 rules fallback against a mock API server
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Proxmox environments where HA group data is unavailable.
  * HA node-affinity rules are now used as a fallback to identify applicable HA groups.
  * Preserved expected not-found behavior when no matching group or rule exists.

* **Tests**
  * Added coverage for both standard HA group responses and node-affinity fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->